### PR TITLE
Clans in nametags and scoreboard

### DIFF
--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Clan.java
@@ -2,11 +2,15 @@ package net.sacredlabyrinth.phaed.simpleclans;
 
 import net.sacredlabyrinth.phaed.simpleclans.uuid.UUIDMigration;
 import net.sacredlabyrinth.phaed.simpleclans.events.*;
+
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.Team;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
@@ -61,7 +65,7 @@ public class Clan implements Serializable, Comparable<Clan>
     public Clan(String tag, String name, boolean verified)
     {
         this.tag = Helper.cleanTag(tag);
-        this.colorTag = Helper.parseColors(tag);
+        this.colorTag = Helper.parseColors(Helper.selectColor(tag));
         this.name = name;
         this.founded = (new Date()).getTime();
         this.lastUsed = (new Date()).getTime();
@@ -1830,13 +1834,16 @@ public class Clan implements Serializable, Comparable<Clan>
         HardcoreTeamPvP.getInstance().getServer().getPluginManager().callEvent(new DisbandClanEvent(this));
         Collection<ClanPlayer> clanPlayers = HardcoreTeamPvP.getInstance().getClanManager().getAllClanPlayers();
         List<Clan> clans = HardcoreTeamPvP.getInstance().getClanManager().getClans();
-
+        HardcoreTeamPvP plugin = HardcoreTeamPvP.getInstance();
+        Scoreboard board = Bukkit.getScoreboardManager().getMainScoreboard();
         for (ClanPlayer cp : clanPlayers)
         {
             if (cp.getTag().equals(getTag()))
             {
                 HardcoreTeamPvP.getInstance().getPermissionsManager().removeClanPermissions(this);
                 cp.setClan(null);
+                Team playerTeam = board.getPlayerTeam(cp.toPlayer());
+                playerTeam.removePlayer(cp.toPlayer());
 
                 if (isVerified())
                 {

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/HardcoreTeamPvP.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/HardcoreTeamPvP.java
@@ -4,9 +4,15 @@ import net.sacredlabyrinth.phaed.simpleclans.executors.*;
 import net.sacredlabyrinth.phaed.simpleclans.listeners.SCEntityListener;
 import net.sacredlabyrinth.phaed.simpleclans.listeners.SCPlayerListener;
 import net.sacredlabyrinth.phaed.simpleclans.managers.*;
+import net.sacredlabyrinth.phaed.simpleclans.utils.HardcoreTeamUtils;
 import net.sacredlabyrinth.phaed.simpleclans.uuid.UUIDMigration;
+
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -114,6 +120,17 @@ public class HardcoreTeamPvP extends JavaPlugin {
         pullMessages();
         logger.info("[HardcoreTeamPvP] Modo Multithreading: " + HardcoreTeamPvP.getInstance().getSettingsManager().getUseThreads());
         logger.info("[HardcoreTeamPvP] Modo BungeeCord: " + HardcoreTeamPvP.getInstance().getSettingsManager().getUseBungeeCord());
+        
+        Bukkit.getServer().getScheduler().scheduleSyncRepeatingTask(this, new Runnable() {
+            @Override
+            public void run() {
+            	HardcoreTeamPvP plugin = (HardcoreTeamPvP) Bukkit.getPluginManager().getPlugin("HardcoreTeamPvP");
+            	for(Player p: Bukkit.getServer().getOnlinePlayers()){
+            		HardcoreTeamUtils.teamColor(p);
+        		}
+            }
+        }, 0L, 20L);
+        
     }
 
     @Override

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Helper.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Helper.java
@@ -418,12 +418,12 @@ public class Helper
 
         if (one.equals("\u00a7"))
         {
-            return one + two;
+            //return one + two;
         }
 
         if (one.equals("&"))
         {
-            return Helper.toColor(two);
+            //return Helper.toColor(two);
         }
 
 

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Helper.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/Helper.java
@@ -1,6 +1,8 @@
 package net.sacredlabyrinth.phaed.simpleclans;
 
+import net.sacredlabyrinth.phaed.simpleclans.*;
 import net.sacredlabyrinth.phaed.simpleclans.uuid.UUIDMigration;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -17,7 +19,7 @@ import java.util.*;
  */
 public class Helper
 {
-
+	public static HardcoreTeamPvP plugin = HardcoreTeamPvP.getInstance();
     /**
      * Dumps stacktrace to log
      */
@@ -418,12 +420,12 @@ public class Helper
 
         if (one.equals("\u00a7"))
         {
-            //return one + two;
+            return one + two;
         }
 
         if (one.equals("&"))
         {
-            //return Helper.toColor(two);
+            return Helper.toColor(two);
         }
 
 
@@ -711,5 +713,23 @@ public class Helper
         }
 
         return HardcoreTeamPvP.getInstance().getServer().getPlayer(playerName);
+    }
+    
+    public static String selectColor(String tag)
+    {
+    	ArrayList<String> colorPool = new ArrayList<String>(Arrays.asList(new String[] {"&0", "&1", "&2", "&3", "&4", "&5", "&6", "&7", "&8", "&9", "&a", "&b", "&c", "&d", "&e"}));
+    	List<Clan> clans = plugin.getClanManager().getClans();
+    	for(int i = 0; i < colorPool.size(); i++){
+    		if(tag.startsWith(colorPool.get(i))){
+    			tag = tag.substring(2);
+    		}
+    		for(int k = 0; k < clans.size(); k++){
+    			if(clans.get(k).getColorTag().contains(colorPool.get(i))){
+    				colorPool.remove(i);
+    			}
+    		}
+    	}
+    	Random randomGenerator = new Random();
+    	return colorPool.get(randomGenerator.nextInt(colorPool.size())) + tag;
     }
 }

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/DisbandCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/DisbandCommand.java
@@ -5,6 +5,7 @@ import net.sacredlabyrinth.phaed.simpleclans.Clan;
 import net.sacredlabyrinth.phaed.simpleclans.ClanPlayer;
 import net.sacredlabyrinth.phaed.simpleclans.HardcoreTeamPvP;
 import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import java.text.MessageFormat;
@@ -90,6 +91,35 @@ public class DisbandCommand
         else
         {
             ChatBlock.sendMessage(player, ChatColor.RED + MessageFormat.format(plugin.getLang("usage.0.disband"), plugin.getSettingsManager().getCommandClan()));
+        }
+    }
+    /**
+     * Execute the command
+     *
+     * @param player
+     * @param arg
+     */
+    public void execute(CommandSender sender, String[] arg)
+    {
+        HardcoreTeamPvP plugin = HardcoreTeamPvP.getInstance();
+
+        if (arg.length == 1)
+        {
+            Clan clan = plugin.getClanManager().getClan(arg[0]);
+
+            if (clan != null)
+            {
+                plugin.getClanManager().serverAnnounce(ChatColor.AQUA + MessageFormat.format(plugin.getLang("clan.has.been.disbanded"), clan.getName()));
+                clan.disband();
+            }
+            else
+            {
+                ChatBlock.sendMessage(sender, ChatColor.RED + plugin.getLang("no.clan.matched"));
+            }
+        }
+        else
+        {
+            ChatBlock.sendMessage(sender, ChatColor.RED + MessageFormat.format(plugin.getLang("usage.0.disband"), plugin.getSettingsManager().getCommandClan()));
         }
     }
 }

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/RestrictToClansCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/RestrictToClansCommand.java
@@ -28,6 +28,7 @@ public class RestrictToClansCommand {
      * @param arg command arguments
      */
     public void execute(CommandSender sender, String[] arg) {
+    	System.out.println("KICK");
         Player playerSender = null;
         if (sender instanceof Player){
             playerSender = (Player) sender;

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/RestrictToClansCommand.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/commands/RestrictToClansCommand.java
@@ -28,7 +28,6 @@ public class RestrictToClansCommand {
      * @param arg command arguments
      */
     public void execute(CommandSender sender, String[] arg) {
-    	System.out.println("KICK");
         Player playerSender = null;
         if (sender instanceof Player){
             playerSender = (Player) sender;

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/executors/AcceptCommandExecutor.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/executors/AcceptCommandExecutor.java
@@ -1,6 +1,8 @@
 package net.sacredlabyrinth.phaed.simpleclans.executors;
 
 import net.sacredlabyrinth.phaed.simpleclans.*;
+import net.sacredlabyrinth.phaed.simpleclans.utils.HardcoreTeamUtils;
+
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -42,6 +44,7 @@ public class AcceptCommandExecutor implements CommandExecutor
                     if (cp.getVote() == null)
                     {
                         plugin.getRequestManager().accept(cp);
+                        HardcoreTeamUtils.teamColor(player);
                         clan.leaderAnnounce(ChatColor.GREEN + MessageFormat.format(plugin.getLang("voted.to.accept"), Helper.capitalize(player.getName())));
                     }
                     else

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/executors/ClanCommandExecutor.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/executors/ClanCommandExecutor.java
@@ -7,6 +7,8 @@ import org.bukkit.command.*;
 import org.bukkit.entity.Player;
 
 import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author phaed
@@ -14,48 +16,8 @@ import java.text.MessageFormat;
 public final class ClanCommandExecutor implements CommandExecutor
 {
     private HardcoreTeamPvP plugin;
-    private CreateCommand createCommand;
-    private ListCommand listCommand;
-    private ProfileCommand profileCommand;
-    private RosterCommand rosterCommand;
-    private LookupCommand lookupCommand;
-    private LeaderboardCommand leaderboardCommand;
-    private AlliancesCommand alliancesCommand;
-    private RivalriesCommand rivalriesCommand;
-    private VitalsCommand vitalsCommand;
-    private CoordsCommand coordsCommand;
-    private StatsCommand statsCommand;
-    private AllyCommand allyCommand;
-    private RivalCommand rivalCommand;
-    private BbCommand bbCommand;
-    private ModtagCommand modtagCommand;
-    private ToggleCommand toggleCommand;
-    private InviteCommand inviteCommand;
-    private KickCommand kickCommand;
-    private TrustCommand trustCommand;
-    private UntrustCommand untrustCommand;
-    private PromoteCommand promoteCommand;
-    private CapeCommand capeCommand;
-    private DemoteCommand demoteCommand;
-    private ClanffCommand clanffCommand;
-    private FfCommand ffCommand;
-    private ResignCommand resignCommand;
-    private DisbandCommand disbandCommand;
-    private VerifyCommand verifyCommand;
-    private BanCommand banCommand;
-    private UnbanCommand unbanCommand;
-    private ReloadCommand reloadCommand;
-    private GlobalffCommand globalffCommand;
     private MenuCommand menuCommand;
-    private WarCommand warCommand;
-    private HomeCommand homeCommand;
-    private KillsCommand killsCommand;
-    private MostKilledCommand mostKilledCommand;
-    private SetRankCommand setRankCommand;
-    private BankCommand bankCommand;
-    private PlaceCommand placeCommand;
-    private ResetKDRCommand resetKDRCommand;
-    private RestrictToClansCommand restrictToClansCommand;
+    private Map<String, Object> commands = new HashMap<String, Object>();
 
     /**
      *
@@ -64,47 +26,47 @@ public final class ClanCommandExecutor implements CommandExecutor
     {
         plugin = HardcoreTeamPvP.getInstance();
         menuCommand = new MenuCommand();
-        createCommand = new CreateCommand();
-        listCommand = new ListCommand();
-        profileCommand = new ProfileCommand();
-        rosterCommand = new RosterCommand();
-        lookupCommand = new LookupCommand();
-        leaderboardCommand = new LeaderboardCommand();
-        alliancesCommand = new AlliancesCommand();
-        rivalriesCommand = new RivalriesCommand();
-        vitalsCommand = new VitalsCommand();
-        coordsCommand = new CoordsCommand();
-        statsCommand = new StatsCommand();
-        allyCommand = new AllyCommand();
-        rivalCommand = new RivalCommand();
-        bbCommand = new BbCommand();
-        modtagCommand = new ModtagCommand();
-        toggleCommand = new ToggleCommand();
-        inviteCommand = new InviteCommand();
-        kickCommand = new KickCommand();
-        trustCommand = new TrustCommand();
-        untrustCommand = new UntrustCommand();
-        promoteCommand = new PromoteCommand();
-        capeCommand = new CapeCommand();
-        demoteCommand = new DemoteCommand();
-        clanffCommand = new ClanffCommand();
-        ffCommand = new FfCommand();
-        resignCommand = new ResignCommand();
-        disbandCommand = new DisbandCommand();
-        verifyCommand = new VerifyCommand();
-        banCommand = new BanCommand();
-        unbanCommand = new UnbanCommand();
-        reloadCommand = new ReloadCommand();
-        globalffCommand = new GlobalffCommand();
-        warCommand = new WarCommand();
-        homeCommand = new HomeCommand();
-        killsCommand = new KillsCommand();
-        mostKilledCommand = new MostKilledCommand();
-        setRankCommand = new SetRankCommand();
-        bankCommand = new BankCommand();
-        placeCommand = new PlaceCommand();
-        resetKDRCommand = new ResetKDRCommand();
-        restrictToClansCommand = new RestrictToClansCommand();
+        commands.put(plugin.getLang("create.command").toLowerCase(), new CreateCommand());
+        commands.put(plugin.getLang("list.command").toLowerCase(), new ListCommand());
+        commands.put(plugin.getLang("bank.command").toLowerCase(), new BankCommand());
+        commands.put(plugin.getLang("profile.command").toLowerCase(), new ProfileCommand());
+        commands.put(plugin.getLang("roster.command").toLowerCase(), new RosterCommand());
+        commands.put(plugin.getLang("lookup.command").toLowerCase(), new LookupCommand());
+        commands.put(plugin.getLang("home.command").toLowerCase(), new HomeCommand());
+        commands.put(plugin.getLang("leaderboard.command").toLowerCase(), new LeaderboardCommand());
+        commands.put(plugin.getLang("alliances.command").toLowerCase(), new AlliancesCommand());
+        commands.put(plugin.getLang("rivalries.command").toLowerCase(), new RivalriesCommand());
+        commands.put(plugin.getLang("vitals.command").toLowerCase(), new VitalsCommand());
+        commands.put(plugin.getLang("coords.command").toLowerCase(), new CoordsCommand());
+        commands.put(plugin.getLang("stats.command").toLowerCase(), new StatsCommand());
+        commands.put(plugin.getLang("ally.command").toLowerCase(), new AllyCommand());
+        commands.put(plugin.getLang("rival.command").toLowerCase(), new RivalCommand());
+        commands.put(plugin.getLang("bb.command").toLowerCase(), new BbCommand());
+        commands.put(plugin.getLang("modtag.command").toLowerCase(), new ModtagCommand());
+        commands.put(plugin.getLang("toggle.command").toLowerCase(), new ToggleCommand());
+        commands.put(plugin.getLang("cape.command").toLowerCase(), new CapeCommand());
+        commands.put(plugin.getLang("invite.command").toLowerCase(), new InviteCommand());
+        commands.put(plugin.getLang("kick.command").toLowerCase(), new KickCommand());
+        commands.put(plugin.getLang("trust.command").toLowerCase(), new TrustCommand());
+        commands.put(plugin.getLang("untrust.command").toLowerCase(), new UntrustCommand());
+        commands.put(plugin.getLang("promote.command").toLowerCase(), new PromoteCommand());
+        commands.put(plugin.getLang("demote.command").toLowerCase(), new DemoteCommand());
+        commands.put(plugin.getLang("clanff.command").toLowerCase(), new ClanffCommand());
+        commands.put(plugin.getLang("ff.command").toLowerCase(), new FfCommand());
+        commands.put(plugin.getLang("resign.command").toLowerCase(), new ResignCommand());
+        commands.put(plugin.getLang("disband.command").toLowerCase(), new DisbandCommand());
+        commands.put(plugin.getLang("verify.command").toLowerCase(), new VerifyCommand());
+        commands.put(plugin.getLang("ban.command").toLowerCase(), new BanCommand());
+        commands.put(plugin.getLang("unban.command").toLowerCase(), new UnbanCommand());
+        commands.put(plugin.getLang("reload.command").toLowerCase(), new ReloadCommand());
+        commands.put(plugin.getLang("globalff.command").toLowerCase(), new GlobalffCommand());
+        commands.put(plugin.getLang("war.command").toLowerCase(), new WarCommand());
+        commands.put(plugin.getLang("kills.command").toLowerCase(), new KillsCommand());
+        commands.put(plugin.getLang("mostkilled.command").toLowerCase(), new MostKilledCommand());
+        commands.put(plugin.getLang("setrank.command").toLowerCase(), new SetRankCommand());
+        commands.put(plugin.getLang("place.command").toLowerCase(), new PlaceCommand());
+        commands.put(plugin.getLang("resetkdr.command").toLowerCase(), new ResetKDRCommand());
+        commands.put(plugin.getLang("restrict.command").toLowerCase(), new RestrictToClansCommand());
     }
 
     @Override
@@ -135,171 +97,12 @@ public final class ClanCommandExecutor implements CommandExecutor
                 {
                     String subcommand = args[0];
                     String[] subargs = Helper.removeFirst(args);
-
-                    if (subcommand.equalsIgnoreCase(plugin.getLang("create.command")))
-                    {
-                        createCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("list.command")))
-                    {
-                        listCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("bank.command")))
-                    {
-                        bankCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("profile.command")))
-                    {
-                        profileCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("roster.command")))
-                    {
-                        rosterCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("lookup.command")))
-                    {
-                        lookupCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("home.command")))
-                    {
-                        homeCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("leaderboard.command")))
-                    {
-                        leaderboardCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("alliances.command")))
-                    {
-                        alliancesCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("rivalries.command")))
-                    {
-                        rivalriesCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("vitals.command")))
-                    {
-                        vitalsCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("coords.command")))
-                    {
-                        coordsCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("stats.command")))
-                    {
-                        statsCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("ally.command")))
-                    {
-                        allyCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("rival.command")))
-                    {
-                        rivalCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("bb.command")))
-                    {
-                        bbCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("modtag.command")))
-                    {
-                        modtagCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("toggle.command")))
-                    {
-                        toggleCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("cape.command")))
-                    {
-                        capeCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("invite.command")))
-                    {
-                        inviteCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("kick.command")))
-                    {
-                        kickCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("trust.command")))
-                    {
-                        trustCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("untrust.command")))
-                    {
-                        untrustCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("promote.command")))
-                    {
-                        promoteCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("demote.command")))
-                    {
-                        demoteCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("clanff.command")))
-                    {
-                        clanffCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("ff.command")))
-                    {
-                        ffCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("resign.command")))
-                    {
-                        resignCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("disband.command")))
-                    {
-                        disbandCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("verify.command")))
-                    {
-                        verifyCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("ban.command")))
-                    {
-                        banCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("unban.command")))
-                    {
-                        unbanCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("reload.command")))
-                    {
-                        reloadCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("globalff.command")))
-                    {
-                        globalffCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("war.command")))
-                    {
-                        warCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("kills.command")))
-                    {
-                        killsCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("mostkilled.command")))
-                    {
-                        mostKilledCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("setrank.command")))
-                    {
-                        setRankCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("place.command")))
-                    {
-                        placeCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("resetkdr.command")))
-                    {
-                        resetKDRCommand.execute(player, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("restrict.command")))
-                    {
-                        restrictToClansCommand.execute(player, subargs);
-                    }
+                    
+                	if(commands.containsKey(subcommand.toLowerCase()))
+                	{
+                		Object obj = commands.get(subcommand.toLowerCase());
+                		obj.getClass().getMethod("execute", Player.class, String[].class).invoke(obj, player, subargs);
+                	}
                     else
                     {
                         ChatBlock.sendMessage(player, ChatColor.RED + plugin.getLang("does.not.match"));
@@ -317,22 +120,11 @@ public final class ClanCommandExecutor implements CommandExecutor
                     String subcommand = args[0];
                     String[] subargs = Helper.removeFirst(args);
 
-                    if (subcommand.equalsIgnoreCase(plugin.getLang("verify.command")))
-                    {
-                        verifyCommand.execute(sender, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("reload.command")))
-                    {
-                        reloadCommand.execute(sender, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("place.command")))
-                    {
-                        placeCommand.execute(sender, subargs);
-                    }
-                    else if (subcommand.equalsIgnoreCase(plugin.getLang("restrict.command")))
-                    {
-                        restrictToClansCommand.execute(sender, subargs);
-                    }
+                    if(commands.containsKey(subcommand.toLowerCase()))
+                	{
+                		Object obj = commands.get(subcommand.toLowerCase());
+                		obj.getClass().getMethod("execute", CommandSender.class, String[].class).invoke(obj, sender, subargs);
+                	}
                     else
                     {
                         ChatBlock.sendMessage(sender, ChatColor.RED + plugin.getLang("does.not.match"));

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/listeners/SCPlayerListener.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/listeners/SCPlayerListener.java
@@ -5,6 +5,7 @@ import net.sacredlabyrinth.phaed.simpleclans.ClanPlayer;
 import net.sacredlabyrinth.phaed.simpleclans.HardcoreTeamPvP;
 import net.sacredlabyrinth.phaed.simpleclans.Helper;
 import net.sacredlabyrinth.phaed.simpleclans.executors.*;
+import net.sacredlabyrinth.phaed.simpleclans.utils.HardcoreTeamUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -225,7 +226,8 @@ public class SCPlayerListener implements Listener {
             if (plugin.getSettingsManager().isChatTags()) {
                 if (cp != null && cp.isTagEnabled()) {
                     String tagLabel = cp.getClan().getTagLabel(cp.isLeader());
-
+                    tagLabel += "\u00A7f";
+                    
                     Player player = event.getPlayer();
 
                     if (player.getDisplayName().contains("{clan}")) {
@@ -256,7 +258,9 @@ public class SCPlayerListener implements Listener {
         if (HardcoreTeamPvP.getInstance().getSettingsManager().isBlacklistedWorld(player.getLocation().getWorld().getName())) {
             return;
         }
-
+        
+        HardcoreTeamUtils.teamColor(player);
+        
         ClanPlayer cp;
         if (HardcoreTeamPvP.getInstance().getSettingsManager().getUseBungeeCord()) {
             cp = HardcoreTeamPvP.getInstance().getClanManager().getClanPlayerJoinEvent(player);

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/utils/HardcoreTeamUtils.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/utils/HardcoreTeamUtils.java
@@ -1,0 +1,47 @@
+package net.sacredlabyrinth.phaed.simpleclans.utils;
+
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.Team;
+import org.getspout.spout.player.SpoutCraftPlayer;
+
+import net.sacredlabyrinth.phaed.simpleclans.Clan;
+import net.sacredlabyrinth.phaed.simpleclans.HardcoreTeamPvP;
+
+import java.lang.reflect.Field;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.HumanEntity;
+
+public class HardcoreTeamUtils {
+	public static Team staticColor;
+	public static void teamColor(Player p){
+		HardcoreTeamPvP plugin = HardcoreTeamPvP.getInstance();
+		if(plugin.getClanManager()==null || plugin.getClanManager().getClanPlayer(p)==null){
+			return;
+		}
+        Scoreboard board = Bukkit.getScoreboardManager().getMainScoreboard();
+        Team playerTeam = board.getPlayerTeam(p);
+		Clan playerClan = plugin.getClanManager().getClanPlayer(p).getClan();
+		if((playerClan!=null && playerTeam==null) || (playerClan.getName() != playerTeam.getName())){
+			try {	            
+	            if(board.getTeam(playerClan.getTag()) == null){
+	            	System.out.println("Team for " + p.getName() + "'s clan does not exist. Creating new team.");
+	            	playerTeam = board.registerNewTeam(playerClan.getTag());
+	            }
+	            else if(board.getTeam(playerClan.getTag()).getName().equalsIgnoreCase(playerClan.getTag())){
+	            	playerTeam = board.getTeam(playerClan.getTag());
+	            }
+	            
+	            playerTeam.addPlayer(p);
+	            playerTeam.setPrefix(playerClan.getColorTag()+" ");
+	            staticColor = playerTeam;
+	        }
+	        catch (NullPointerException board1) {
+	            // empty catch block
+	        }
+		}
+		 p.setScoreboard(board);
+    }
+}

--- a/src/main/java/net/sacredlabyrinth/phaed/simpleclans/utils/HardcoreTeamUtils.java
+++ b/src/main/java/net/sacredlabyrinth/phaed/simpleclans/utils/HardcoreTeamUtils.java
@@ -14,6 +14,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.HumanEntity;
 
+/**
+ * @author Ageudum & firestar
+ */
+
 public class HardcoreTeamUtils {
 	public static Team staticColor;
 	public static void teamColor(Player p){
@@ -24,6 +28,7 @@ public class HardcoreTeamUtils {
         Scoreboard board = Bukkit.getScoreboardManager().getMainScoreboard();
         Team playerTeam = board.getPlayerTeam(p);
 		Clan playerClan = plugin.getClanManager().getClanPlayer(p).getClan();
+	
 		if((playerClan!=null && playerTeam==null) || (playerClan.getName() != playerTeam.getName())){
 			try {	            
 	            if(board.getTeam(playerClan.getTag()) == null){


### PR DESCRIPTION
Revised some code from firestar's fork to implement colored clan-names
in player nametags and the scoreboard. Also fixed bug from firestar's
fork where player name and message in chat is dark red.
